### PR TITLE
Add basic player head functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,10 @@
     </dependency>
   </dependencies>
 
+  <!-- move target .jar to my Minecraft Server 
   <build>
     <plugins>
     
-    <!-- move target .jar to my Minecraft Server -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -70,5 +70,6 @@
 
     </plugins>
   </build>
+  -->
 
 </project>

--- a/src/main/java/online/meinkraft/highscores/HighScores.java
+++ b/src/main/java/online/meinkraft/highscores/HighScores.java
@@ -6,7 +6,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -45,7 +45,7 @@ public class HighScores extends JavaPlugin implements Listener {
     }
 
     @EventHandler
-    public void onPlayerLogin(PlayerLoginEvent event) {
+    public void onPlayerQuit(PlayerQuitEvent event) {
         BukkitRunnable task = new UpdatePlayerTask(this, event.getPlayer());
         task.runTaskAsynchronously(this);
     }

--- a/src/main/java/online/meinkraft/highscores/block/HighScoreBlock.java
+++ b/src/main/java/online/meinkraft/highscores/block/HighScoreBlock.java
@@ -1,0 +1,44 @@
+package online.meinkraft.highscores.block;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.Location;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+
+import online.meinkraft.highscores.table.Entry;
+
+public abstract class HighScoreBlock implements ConfigurationSerializable {
+
+    protected final Location location;
+    protected final Integer rank;
+
+    public HighScoreBlock(Location location, Integer rank) {
+        this.location = location;
+        this.rank = rank;
+    }
+
+    public HighScoreBlock(Map<String, Object> map) {
+        location = (Location) map.get("location");
+        rank = (Integer) map.get("rank");
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public Integer getRank() {
+        return rank;
+    }
+
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("location", location.serialize());
+        map.put("rank", rank);
+        return map;
+    }
+
+    public abstract boolean update(Entry entry);
+    
+}

--- a/src/main/java/online/meinkraft/highscores/block/HighScoreSign.java
+++ b/src/main/java/online/meinkraft/highscores/block/HighScoreSign.java
@@ -1,0 +1,20 @@
+package online.meinkraft.highscores.block;
+
+import org.bukkit.Location;
+
+import online.meinkraft.highscores.table.Entry;
+
+public class HighScoreSign extends HighScoreBlock {
+
+    public HighScoreSign(Location location, Integer rank) {
+        super(location, rank);
+        //TODO Auto-generated constructor stub
+    }
+
+    @Override
+    public boolean update(Entry entry) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+}

--- a/src/main/java/online/meinkraft/highscores/block/HighScoreSkull.java
+++ b/src/main/java/online/meinkraft/highscores/block/HighScoreSkull.java
@@ -1,0 +1,31 @@
+package online.meinkraft.highscores.block;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Skull;
+
+import online.meinkraft.highscores.table.Entry;
+
+public class HighScoreSkull extends HighScoreBlock {
+
+    public HighScoreSkull(Location location, Integer rank) {
+        super(location, rank);
+    }
+
+    @Override
+    public boolean update(Entry entry) {
+        Block block = location.getWorld().getBlockAt(location);
+        if(block.getType() == Material.PLAYER_HEAD) {
+            Skull skull = (Skull) block.getState();
+            skull.setOwningPlayer(entry.getPlayer());
+            skull.update();
+            return true;
+        }
+        else {
+            return false;
+        }
+        
+    }
+    
+}

--- a/src/main/java/online/meinkraft/highscores/command/HighScoresCommand.java
+++ b/src/main/java/online/meinkraft/highscores/command/HighScoresCommand.java
@@ -3,6 +3,8 @@ package online.meinkraft.highscores.command;
 import java.io.IOException;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -14,6 +16,8 @@ import online.meinkraft.highscores.exception.TableNotFoundException;
 import online.meinkraft.highscores.table.Table;
 
 public class HighScoresCommand implements CommandExecutor{
+
+    private static final int MAX_BLOCK_DISTANCE = 32;
 
     private final HighScores plugin;
 
@@ -78,12 +82,14 @@ public class HighScoresCommand implements CommandExecutor{
             case "sign":
                 tableName = args[1];
                 rank = Integer.parseInt(args[2]);
-                addSign(sender, tableName, rank);
+                setSign(sender, tableName, rank);
                 break;
+            case "skull":
             case "head":
+            case "playerhead":
                 tableName = args[1];
                 rank = Integer.parseInt(args[2]);
-                addHead(sender, tableName, rank);
+                setSkull(sender, tableName, rank);
                 break;
             case "help":
             default:
@@ -110,7 +116,8 @@ public class HighScoresCommand implements CommandExecutor{
             Table table = new Table(tableName, placeholder);
             table.save(plugin.getTableFolder());
             sender.sendMessage("Table created");
-        } catch (IOException e) {
+        } 
+        catch (IOException e) {
             e.printStackTrace();
         }
     }
@@ -120,11 +127,14 @@ public class HighScoresCommand implements CommandExecutor{
             Table table = Table.getTable(plugin.getTableFolder(), tableName);
             table.delete(plugin.getTableFolder());
             sender.sendMessage("Table destroyed");
-        } catch (IOException e) {
+        } 
+        catch (IOException e) {
             e.printStackTrace();
-        } catch (ClassNotFoundException e) {
+        } 
+        catch (ClassNotFoundException e) {
             e.printStackTrace();
-        } catch (TableNotFoundException e) {
+        } 
+        catch (TableNotFoundException e) {
             e.printStackTrace();
         }
     }
@@ -133,11 +143,14 @@ public class HighScoresCommand implements CommandExecutor{
         try {
             Table table = Table.getTable(plugin.getTableFolder(), tableName);
             sender.sendMessage(table.toString());
-        } catch (ClassNotFoundException e) {
+        } 
+        catch (ClassNotFoundException e) {
             e.printStackTrace();
-        } catch (IOException e) {
+        } 
+        catch (IOException e) {
             e.printStackTrace();
-        } catch (TableNotFoundException e) {
+        } 
+        catch (TableNotFoundException e) {
             e.printStackTrace();
         }
     }
@@ -146,12 +159,42 @@ public class HighScoresCommand implements CommandExecutor{
         sender.sendMessage(Table.listTables(plugin.getTableFolder()).toString());
     }
 
-    private void addSign(CommandSender sender,  String tableName, Integer rank) {
+    private void setSign(CommandSender sender,  String tableName, Integer rank) {
         sender.sendMessage("Sign added");
     }
 
-    private void addHead(CommandSender sender, String tableName, Integer rank) {
-        sender.sendMessage("Player head added");
+    private void setSkull(CommandSender sender, String tableName, Integer rank) {
+
+        try {
+            if(sender instanceof Player) {
+                Player player = (Player) sender;
+                Block targetBlock = player.getTargetBlock(null, MAX_BLOCK_DISTANCE);
+                if(targetBlock.getType() == Material.PLAYER_HEAD) {
+                    Table table = Table.getTable(plugin.getTableFolder(), tableName);
+                    table.setSkull(targetBlock.getLocation(), rank);
+                    sender.sendMessage("Player head added");
+                }
+                else {
+                    sender.sendMessage("You must be looking at a player head");
+                }
+            }
+            else {
+                sender.sendMessage("You must be a player to use this command");
+            }
+        }
+        catch(IndexOutOfBoundsException e) {
+            e.printStackTrace();
+        }
+        catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        } 
+        catch (IOException e) {
+            e.printStackTrace();
+        } 
+        catch (TableNotFoundException e) {
+            e.printStackTrace();
+        }
+
     }
 
     private void help(CommandSender sender) {
@@ -163,13 +206,17 @@ public class HighScoresCommand implements CommandExecutor{
         try {
             table = Table.getTable(plugin.getTableFolder(), tableName);
             sender.sendMessage(table.getEntry(rank).toString());
-        } catch (ClassNotFoundException e) {
+        } 
+        catch (ClassNotFoundException e) {
             e.printStackTrace();
-        } catch (IOException e) {
+        } 
+        catch (IOException e) {
             e.printStackTrace();
-        } catch (TableNotFoundException e) {
+        } 
+        catch (TableNotFoundException e) {
             e.printStackTrace();
-        } catch(IndexOutOfBoundsException e) {
+        } 
+        catch(IndexOutOfBoundsException e) {
             e.printStackTrace();
         }
     }
@@ -179,13 +226,17 @@ public class HighScoresCommand implements CommandExecutor{
             Player player = Bukkit.getPlayer(playerName);
             Table table = Table.getTable(plugin.getTableFolder(), tableName);
             sender.sendMessage(table.getEntry(player).toString());
-        } catch (ClassNotFoundException e) {
+        } 
+        catch (ClassNotFoundException e) {
             e.printStackTrace();
-        } catch (IOException e) {
+        } 
+        catch (IOException e) {
             e.printStackTrace();
-        } catch (TableNotFoundException e) {
+        } 
+        catch (TableNotFoundException e) {
             e.printStackTrace();
-        } catch (PlayerNotFoundException e) {
+        } 
+        catch (PlayerNotFoundException e) {
             e.printStackTrace();
         }
         
@@ -197,7 +248,8 @@ public class HighScoresCommand implements CommandExecutor{
         }
         try {
             Double.parseDouble(value);
-        } catch (NumberFormatException exception) {
+        } 
+        catch (NumberFormatException exception) {
             return false;
         }
         return true;


### PR DESCRIPTION
I've added the basic player head functionality. Currently you can look at a player head (skull) in the game as a player and use the `/hs skull <table name> <rank>` command to make that player head update. I haven't added a remove command yet, it will probably be something like `/hs remove` while looking at the skull/sign.

The blueprint for both the skull and sign are basically the same as illustrated with the _HighScoreBlock_ class. I see them functioning basically the same, although the sign needs a little more work as it's got more information to update. I would like to have customisable sign design specified in the _config.yml_.